### PR TITLE
Search for files in all subfolders

### DIFF
--- a/lib/puppet-ghostbuster.rb
+++ b/lib/puppet-ghostbuster.rb
@@ -12,15 +12,15 @@ class PuppetGhostbuster
   attr_accessor :path
 
   def manifests
-    Dir["#{path}/**/manifests/*.pp"]
+    Dir["#{path}/**/manifests/**/*.pp"]
   end
 
   def templates
-    Dir["#{path}/**/templates/*"]
+    Dir["#{path}/**/templates/**/*"]
   end
 
   def files
-    Dir["#{path}/**/files/*"]
+    Dir["#{path}/**/files/**/*"]
   end
 
   def self.configuration


### PR DESCRIPTION
At the moment puppet-ghostbuster does not recurse as mentioned in the README.md.  
This pull request fixes that.
Now it will also catch classes like `apache::mod::alias` or even deeper nested ones. 
