### PR TITLE
reorder gems in Gemfile/gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,3 @@ inherit_from: .rubocop_todo.yml
 
 inherit_gem:
   voxpupuli-rubocop: rubocop.yml
-
-Naming/FileName:
-  Exclude:
-    - "*.gemspec"

--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,3 @@ group :coverage, optional: ENV['COVERAGE'] != 'yes' do
   gem 'codecov', require: false
   gem 'simplecov-console', require: false
 end
-
-group :development do
-  gem 'rake', '~> 13.0', '>= 13.0.6'
-  gem 'rspec', '~> 3.12'
-  gem 'rspec-collection_matchers', '~> 1.2'
-  gem 'rspec-its', '~> 1.3'
-  gem 'voxpupuli-rubocop', '~> 2.0'
-end

--- a/puppet-ghostbuster.gemspec
+++ b/puppet-ghostbuster.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
   s.add_development_dependency 'coveralls', '>= 0.8', '< 0.9'
-  s.add_development_dependency 'github_changelog_generator', '>= 1.16.0', '< 1.17.0'
   s.add_development_dependency 'jgrep', '>= 1.0.0', '< 2.0.0'
   s.add_development_dependency 'rake', '>= 13.0.0', '< 14.0.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'
+  s.add_development_dependency 'voxpupuli-rubocop', '~> 2.2.0'
   s.add_runtime_dependency 'json', '>= 2.0', '< 3.0'
   s.add_runtime_dependency 'puppet', '>= 6.0', '< 9.0'
   s.add_dependency         'puppet-lint', '>= 1.0', '< 5.0'


### PR DESCRIPTION
We usually have all development gems in the gemspec. Gemfile contains only the release-specific gems.