### PR TITLE
Optimize

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -90,6 +90,7 @@ Style/ClassAndModuleChildren:
 Style/ClassVars:
   Exclude:
     - 'lib/puppet-ghostbuster/puppetdb.rb'
+    - 'lib/puppet-ghostbuster/util.rb'
 
 # Offense count: 9
 # Configuration parameters: AllowedConstants.
@@ -98,6 +99,7 @@ Style/Documentation:
     - 'spec/**/*'
     - 'test/**/*'
     - 'lib/puppet-ghostbuster/puppetdb.rb'
+    - 'lib/puppet-ghostbuster/util.rb'
     - 'lib/puppet-lint/plugins/check_ghostbuster_classes.rb'
     - 'lib/puppet-lint/plugins/check_ghostbuster_defines.rb'
     - 'lib/puppet-lint/plugins/check_ghostbuster_facts.rb'
@@ -114,6 +116,7 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Exclude:
     - 'lib/puppet-ghostbuster/puppetdb.rb'
+    - 'lib/puppet-ghostbuster/util.rb'
     - 'lib/puppet-ghostbuster/version.rb'
     - 'lib/puppet-lint/plugins/check_ghostbuster_classes.rb'
     - 'lib/puppet-lint/plugins/check_ghostbuster_defines.rb'
@@ -167,4 +170,4 @@ Style/ZeroLengthPredicate:
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns.
 # URISchemes: http, https
 Layout/LineLength:
-  Max: 189
+  Max: 195

--- a/lib/puppet-ghostbuster/puppetdb.rb
+++ b/lib/puppet-ghostbuster/puppetdb.rb
@@ -40,9 +40,9 @@ class PuppetGhostbuster
 
     def self.classes
       @@classes ||= client.request('',
-                                   'resources[title] { type = "Class" and nodes { deactivated is null } }').data.map do |r|
+                                   'resources[title] { type = "Class" and nodes { deactivated is null } group by title }').data.map do |r|
         r['title']
-      end.uniq
+      end
     end
 
     def classes
@@ -50,9 +50,9 @@ class PuppetGhostbuster
     end
 
     def self.resources
-      @@resources ||= client.request('', 'resources[type] { nodes { deactivated is null } }').data.map do |r|
+      @@resources ||= client.request('', 'resources[type] { nodes { deactivated is null } group by type }').data.map do |r|
         r['type']
-      end.uniq
+      end
     end
 
     def resources

--- a/lib/puppet-ghostbuster/util.rb
+++ b/lib/puppet-ghostbuster/util.rb
@@ -1,0 +1,19 @@
+class PuppetGhostbuster
+  class Util
+    class << self
+      def search_file(name, search)
+        return search_file_regexp(name, search) if search.is_a?(Regexp)
+
+        File.foreach(name) do |line|
+          return true if line.include?(search)
+        end
+      end
+
+      def search_file_regexp(name, search)
+        File.foreach(name) do |line|
+          return true if line.match?(search)
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet-lint/plugins/check_ghostbuster_facts.rb
+++ b/lib/puppet-lint/plugins/check_ghostbuster_facts.rb
@@ -1,3 +1,5 @@
+require 'puppet-ghostbuster/util'
+
 class PuppetLint::Checks
   def load_data(path, content)
     lexer = PuppetLint::Lexer.new
@@ -25,29 +27,30 @@ PuppetLint.new_check(:ghostbuster_facts) do
     m = path.match(%r{.*/([^/]+)/lib/facter/(.+)$})
     return if m.nil?
 
-    File.readlines(path).grep(/Facter.add\(["']([^"']+)["']\)/).each do |line|
-      fact_name = line.match(/Facter.add\(["']([^"']+)["']\)/).captures[0]
+    File.foreach(path) do |line|
+      if line.match?(/Facter.add\(["']([^"']+)["']\)/)
+        fact_name = line.match(/Facter.add\(["']([^"']+)["']\)/).captures[0]
 
-      found = false
+        found = false
 
-      manifests.each do |manifest|
-        found = true if File.readlines(manifest).grep(/\$\{?::#{fact_name}\}?/).size > 0
-        found = true if File.readlines(manifest).grep(/@#{fact_name}/).size > 0
-        break if found
+        manifests.each do |manifest|
+          found = true unless PuppetGhostbuster::Util.search_file(manifest, /(\$\{?::#{fact_name}\}?|@#{fact_name})/).nil?
+          break if found
+        end
+
+        templates.each do |template|
+          found = true unless PuppetGhostbuster::Util.search_file(template, /@#{fact_name}/).nil?
+          break if found
+        end
+
+        next if found
+
+        notify :warning, {
+          message: "Fact #{fact_name} seems unused",
+          line: 1,
+          column: 1,
+        }
       end
-
-      templates.each do |template|
-        found = true if File.readlines(template).grep(/@#{fact_name}/).size > 0
-        break if found
-      end
-
-      next if found
-
-      notify :warning, {
-        message: "Fact #{fact_name} seems unused",
-        line: 1,
-        column: 1,
-      }
     end
   end
 end

--- a/lib/puppet-lint/plugins/check_ghostbuster_facts.rb
+++ b/lib/puppet-lint/plugins/check_ghostbuster_facts.rb
@@ -28,8 +28,8 @@ PuppetLint.new_check(:ghostbuster_facts) do
     return if m.nil?
 
     File.foreach(path) do |line|
-      if line.match?(/Facter.add\(["']([^"']+)["']\)/)
-        fact_name = line.match(/Facter.add\(["']([^"']+)["']\)/).captures[0]
+      if line =~ /Facter.add\(["':](?<fact>[^"'\)]+)["']?\)/
+        fact_name = Regexp.last_match(:fact)
 
         found = false
 

--- a/lib/puppet-lint/plugins/check_ghostbuster_files.rb
+++ b/lib/puppet-lint/plugins/check_ghostbuster_files.rb
@@ -1,4 +1,5 @@
 require 'puppet-ghostbuster/puppetdb'
+require 'puppet-ghostbuster/util'
 
 class PuppetLint::Checks
   def load_data(path, content)
@@ -42,9 +43,9 @@ PuppetLint.new_check(:ghostbuster_files) do
     end
 
     manifests.each do |manifest|
-      return if File.readlines(manifest).grep(%r{["']#{module_name}/#{file_name}["']}).size > 0
+      return if PuppetGhostbuster::Util.search_file(manifest, %r{["']#{module_name}/#{file_name}["']})
 
-      if (match = manifest.match(%r{.*/([^/]+)/manifests/.+$})) && (match.captures[0] == module_name) && (File.readlines(manifest).grep(%r{["']\$\{module_name\}/#{file_name}["']}).size > 0)
+      if (match = manifest.match(%r{.*/([^/]+)/manifests/.+$})) && (match.captures[0] == module_name) && PuppetGhostbuster::Util.search_file(manifest, %r{["']\$\{module_name\}/#{file_name}["']})
         return
       end
     end

--- a/lib/puppet-lint/plugins/check_ghostbuster_functions.rb
+++ b/lib/puppet-lint/plugins/check_ghostbuster_functions.rb
@@ -1,3 +1,5 @@
+require 'puppet-ghostbuster/util'
+
 class PuppetLint::Checks
   def load_data(path, content)
     lexer = PuppetLint::Lexer.new
@@ -28,12 +30,11 @@ PuppetLint.new_check(:ghostbuster_functions) do
     function_name = m.captures[0]
 
     manifests.each do |manifest|
-      return if File.readlines(manifest).grep(/#{function_name}\(/).size > 0
+      return if PuppetGhostbuster::Util.search_file(manifest, "#{function_name}(")
     end
 
     templates.each do |template|
-      return if File.readlines(template).grep(/scope.function_#{function_name}\(/).size > 0
-      return if File.readlines(template).grep(/Puppet::Parser::Functions.function\(:#{function_name}/).size > 0
+      return if PuppetGhostbuster::Util.search_file(template, /(Puppet::Parser::Functions\.function\(:|scope\.function_)#{function_name}/)
     end
 
     notify :warning, {

--- a/spec/fixtures/hiera.yaml
+++ b/spec/fixtures/hiera.yaml
@@ -1,6 +1,12 @@
 ---
 version: 5
+defaults:
+  datadir: data
 hierarchy:
+  - name: "Some other location"
+    datadir: private/
+    path: "nodes/%{trusted.certname}.eyaml"
+
   - name: "Per-node data (yaml version)"
     path: "nodes/%{trusted.certname}.yaml"
 

--- a/spec/fixtures/modules/foo/lib/facter/asym.rb
+++ b/spec/fixtures/modules/foo/lib/facter/asym.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Fact is a symbol
+Facter.add(:asym) do
+  setcode do
+    'asym'
+  end
+end

--- a/spec/puppet-lint/plugins/ghostbuster_facts_spec.rb
+++ b/spec/puppet-lint/plugins/ghostbuster_facts_spec.rb
@@ -53,5 +53,17 @@ describe 'ghostbuster_facts' do
         expect(problems.size).to eq(0)
       end
     end
+
+    context 'when added fact is a symbol and unused' do
+      let(:path) { './spec/fixtures/modules/foo/lib/facter/asym.rb' }
+
+      it 'detects one problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'creates a warning' do
+        expect(problems).to contain_warning('Fact asym seems unused')
+      end
+    end
   end
 end

--- a/spec/puppet-lint/plugins/ghostbuster_hiera_files_spec.rb
+++ b/spec/puppet-lint/plugins/ghostbuster_hiera_files_spec.rb
@@ -9,19 +9,19 @@ describe 'ghostbuster_hiera_files' do
 
   context 'with fix disabled' do
     context 'when a certname file is NOT used' do
-      let(:path) { './hieradata/nodes/foo.example.com.yaml' }
+      let(:path) { './data/nodes/foo.example.com.yaml' }
 
       it 'detects one problem' do
         expect(problems.size).to eq(1)
       end
 
       it 'creates a warning' do
-        expect(problems).to contain_warning('Hiera File nodes/foo.example.com.yaml seems unused')
+        expect(problems).to contain_warning("Hiera File #{path} seems unused")
       end
     end
 
     context 'when a certname file is used' do
-      let(:path) { './hieradata/nodes/bar.example.com.yaml' }
+      let(:path) { './data/nodes/bar.example.com.yaml' }
 
       it 'does not detect any problem' do
         expect(problems.size).to eq(0)
@@ -29,19 +29,19 @@ describe 'ghostbuster_hiera_files' do
     end
 
     context 'when an environment file is NOT used' do
-      let(:path) { './hieradata/environment/foo.yaml' }
+      let(:path) { './data/environment/foo.yaml' }
 
       it 'detects one problem' do
         expect(problems.size).to eq(1)
       end
 
       it 'creates a warning' do
-        expect(problems).to contain_warning('Hiera File environment/foo.yaml seems unused')
+        expect(problems).to contain_warning("Hiera File #{path} seems unused")
       end
     end
 
     context 'when an environment file is used' do
-      let(:path) { './hieradata/environment/production.yaml' }
+      let(:path) { './data/environment/production.yaml' }
 
       it 'does not detect any problem' do
         expect(problems.size).to eq(0)
@@ -49,30 +49,54 @@ describe 'ghostbuster_hiera_files' do
     end
 
     context 'when an fact is NOT used' do
-      let(:path) { './hieradata/virtual/false.yaml' }
+      let(:path) { './data/virtual/false.yaml' }
 
       it 'detects one problem' do
         expect(problems.size).to eq(1)
       end
 
       it 'creates a warning' do
-        expect(problems).to contain_warning('Hiera File virtual/false.yaml seems unused')
+        expect(problems).to contain_warning("Hiera File #{path} seems unused")
       end
     end
 
     context 'when an fact file is used' do
-      let(:path) { './hieradata/virtual/true.yaml' }
+      let(:path) { './data/virtual/true.yaml' }
 
       it 'does not detect any problem' do
         expect(problems.size).to eq(0)
       end
     end
 
+    context 'when an fact file is used with wrong extension' do
+      let(:path) { './data/virtual/true.eyaml' }
+
+      it 'detects one problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'creates a warning' do
+        expect(problems).to contain_warning("Hiera File #{path} seems unused")
+      end
+    end
+
     context 'when using a variable in hierarchy' do
-      let(:path) { './hieradata/domain/example.com.yaml' }
+      let(:path) { './data/domain/example.com.yaml' }
 
       it 'does not detect any problem' do
         expect(problems.size).to eq(0)
+      end
+    end
+
+    context 'when hierarchy datadir is NOT default and NOT used' do
+      let(:path) { './private/nodes/privates.example.com.eyaml' }
+
+      it 'detects one problem' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'creates a warning' do
+        expect(problems).to contain_warning("Hiera File #{path} seems unused")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ class PuppetDB::Client
     endpoint_cols = query.split('{').first
     endpoint = endpoint_cols.split(/[\s\[]/).first
     query.sub!(/^#{Regexp.quote(endpoint_cols)}\{\s*/, '')
+    query.sub!(/(group\s+by\s+(type|title))/, '')
     query.sub!(/\s*}\s*/, '')
     query.sub!(/(and\s+)?nodes\s*\{\s*deactivated\s+is\s+null\s*\}/, '')
 


### PR DESCRIPTION
* read file by line until match
* only read files once per check
* prefer include over match
* support hiera datadir

Replacing readlines.grep also happens to fix #63.
Tried to create a test, but I was unable to reproduce outside of a production environment.