### PR TITLE
support check_ghostbuster_files for directories with recurse = 'remote'

### DIFF
--- a/lib/puppet-lint/plugins/check_ghostbuster_files.rb
+++ b/lib/puppet-lint/plugins/check_ghostbuster_files.rb
@@ -35,7 +35,7 @@ PuppetLint.new_check(:ghostbuster_files) do
       query = "resources[title] {
         (parameters.source = 'puppet:///modules/#{module_name}/#{dir_name}'
          or parameters.source = 'puppet:///modules/#{module_name}/#{dir_name}/')
-        and parameters.recurse = true
+        and (parameters.recurse = true or parameters.recurse = 'remote')
         and nodes { deactivated is null } }"
       return if puppetdb.client.request('', query).data.size > 0
 


### PR DESCRIPTION
first of all, thanks for this very useful module.

this very small patch is to avoid false positive for this type of our file resources:
```
 21     file { '/usr/local/mydir':
 22       ensure  => directory,
 23       recurse => remote,
 24       source  => 'puppet:///modules/infra/mydir',
 25       notify  => Service['mysvc']
 26     }
```
(recurse doc: https://www.puppet.com/docs/puppet/8/types/file.html#file-attribute-recurse )
